### PR TITLE
Use seconds for cloudbuild.yaml timeout.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,4 @@ steps:
   entrypoint: 'bash'
   args: ['-c', './integration_tests/run_tests_on_vm.sh']
 
-timeout: '20m'
-
-
+timeout: '1200s'


### PR DESCRIPTION
The duration proto JSON spec doesn't actually support other duration formats
outside of seconds. The fact that it does is primarily a side effect of the
current Go implementation.

See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto#L92-L100
for more details.